### PR TITLE
Adds account selection checklist 

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -74,6 +74,8 @@ class MockDB(AppDB):
     def randomTransaction(self, i):
         categories = [c for c in self.getCategories() if c != "UNKNOWN" and c != "TRANSFER"]
         cat = categories[random.randrange(0,len(categories))]
+        accounts = ["101010-00001234", "101010-00005678", "101010-00009101"]
+        acct = accounts[random.randrange(0,len(accounts))]
         return {
             "id": i,
             "Date": (
@@ -83,7 +85,7 @@ class MockDB(AppDB):
             "Value": self.randomTValue(cat),
             "Balance": 0,
             "Account Name": "someAccount",
-            "Account Number": "101010-00001234",
+            "Account Number": acct,
             "Category": cat
         }
 

--- a/app/pages/econ.py
+++ b/app/pages/econ.py
@@ -1,9 +1,13 @@
 import dash
-from dash import html, dcc
+from dash import dcc, callback, html
+from dash.dependencies import Input, Output, State
+from dash.exceptions import PreventUpdate
 
 import config
 import appsecrets as ss
 from transactions import data, viz 
+
+from log import log
 
 dash.register_page(__name__, order=2)
 
@@ -11,22 +15,44 @@ def layout():
     transactions=config.db.getTransactions()
     transactionsByMonth=data.transactionsByMonth(transactions, ss.transactions["firstDayOfMonth"])
     
+    accounts = data.accounts(transactions).to_dict('records')
+
+    log.debug(accounts)
+
     return html.Div(children=[
-  
-        html.H1('Expenses by month'),       
+
+        html.H2('Select accounts'),       
+        dcc.Checklist(
+            accounts,
+            [idx.get('value') for idx in accounts],
+            id='account_checklist',
+            style={
+                'display': 'flex', 
+                'flex-wrap': 'wrap', 
+                'align-items': 'center', 
+                'justify-content': 'space-evenly',
+                'align-content': 'space-between',
+                'font-size': '75%'
+            },
+            inline=True
+        ),
+        html.Button('Select All', id='select-all-accounts-button', n_clicks=0),
+        html.Button('Deselect All', id='deselect-all-accounts-button', n_clicks=0),
+        
+        html.H2('Expenses by month'),       
         dcc.Graph(
             id='month_bars',
             className='month_bars',
             figure=viz.month_bars(transactionsByMonth)
         ),
         
-        html.H1('Balance per month'),
+        html.H2('Balance per month'),
         dcc.Graph(
             id='month_balance',
             figure=viz.month_balance_graph(transactionsByMonth)
         ),
         
-        html.H1('Cumulative balance per month'),
+        html.H2('Cumulative balance per month'),
         dcc.Graph(
             id='month_cumbalance',
             figure=viz.month_cumulative_graph(transactionsByMonth)
@@ -40,3 +66,36 @@ def layout():
         ),
   ], className="econ")
 
+
+@callback(
+        Output('account_checklist', 'value'),
+    [
+        Input('select-all-accounts-button', 'n_clicks'),
+        Input('deselect-all-accounts-button', 'n_clicks')
+    ],
+    [
+        State('account_checklist', 'options')
+    ]
+)
+def select_all_accounts(select_n_clicks, deselect_n_clicks, options):
+    ctx = [*dash.callback_context.triggered_prop_ids.values()]
+    if not ctx:
+        raise PreventUpdate
+    ctx_caller = ctx[0]
+    log.debug("Clicked: " + ctx_caller)
+    if ctx_caller == 'select-all-accounts-button':
+        return [idx.get('value') for idx in options] 
+    if ctx_caller == 'deselect-all-accounts-button':
+        return []
+    raise PreventUpdate
+    
+@callback(
+    Output('month_bars', 'figure'),
+    Input('account_checklist', 'value'),
+    prevent_initial_call=True
+)
+def update_selected_accounts(values):
+    transactions=config.db.getTransactions()
+    transactionsByMonth=data.transactionsByMonth(transactions, ss.transactions["firstDayOfMonth"])
+    return viz.month_bars(transactionsByMonth, values)
+    

--- a/app/transactions/data.py
+++ b/app/transactions/data.py
@@ -13,13 +13,25 @@ def expensesByCategory(transactions):
     log.debug(expbycat)
     return expbycat;
 
+def accounts(transactions):
+    accts = transactions[['Account Name','Account Number']].drop_duplicates() 
+    result = pd.DataFrame({
+        "label": accts['Account Name'] + ' - ' + accts['Account Number'],
+        "value": accts['Account Number']
+    }).reset_index(drop=True)
+    return result;
+
 def transactionsByMonth(transactions, firstDayOfMonth=17):
-    transbymonth = transactions[['Date','Category','Value']]
+    transbymonth = transactions[['Date','Category','Value','Account Number']]
     transbymonth['Date'] = transbymonth['Date'].apply(lambda x: (x - timedelta(days=firstDayOfMonth-1)).strftime('%Y-%m'))
     return transbymonth;
 
-def expensesByMonth(transByMonth):
-    expbymonth = transByMonth.groupby(['Date','Category'], as_index=False).sum().round(2)
+def expensesByMonth(transByMonth, accounts=[]):
+    if not accounts:
+        trans = transByMonth
+    else:
+        trans = transByMonth[transByMonth['Account Number'].isin(accounts)]
+    expbymonth = trans.groupby(['Date','Category'], as_index=False).sum().round(2)
     expbymonth = expbymonth.loc[~expbymonth['Category'].isin(db.getNonExpenseCategories())]
     expbymonth['Value'] *= -1
 

--- a/app/transactions/viz.py
+++ b/app/transactions/viz.py
@@ -9,8 +9,8 @@ def category_pie(transactions):
                   names='Category'
                   )
 
-def month_bars(transByMonth):
-    df = data.expensesByMonth(transByMonth)
+def month_bars(transByMonth, accounts=[]):
+    df = data.expensesByMonth(transByMonth, accounts)
     fig1 = px.bar(df, 
                   y="Value", 
                   x="Date", 


### PR DESCRIPTION
Adds a checklist at the top of the economy page to filter monthly bars (and perhaps other graphs in the future) by account number.